### PR TITLE
Explicit Locale usage to fix a crash when closing the main window

### DIFF
--- a/elite-copilot.py
+++ b/elite-copilot.py
@@ -910,7 +910,7 @@ class CopilotWidget(QWidget):
         log = self.MessageWidget.toPlainText()
         with open("%s.log" % APPNAME, "at") as f:
             # noinspection PyArgumentList
-            time_string = QDateTime.toString(QDateTime.currentDateTime())
+            time_string = QLocale(QLocale.English).toString(QDateTime.currentDateTime(), QLocale.ShortFormat)
             f.write("\n*********************************************************\n")
             f.write(time_string)
             f.write("\n*********************************************************\n")


### PR DESCRIPTION
On my french windows, using QDateTime.toString() would use the french locale, and then fail to write unicode characters to the log file when closing the app. This would trigger an exception and keep the overlay opened.
